### PR TITLE
feat: add ledger derivation at address index

### DIFF
--- a/src/dlc-handlers/ledger-dlc-handler.ts
+++ b/src/dlc-handlers/ledger-dlc-handler.ts
@@ -296,10 +296,8 @@ export class LedgerDLCHandler {
     customFeeRate?: bigint
   ): Promise<Psbt> {
     try {
-      const { fundingPayment, fundingDerivedPublicKey, multisigPayment } = await this.createPayment(
-        vault.uuid,
-        attestorGroupPublicKey
-      );
+      const { fundingPayment, fundingDerivedPublicKey, taprootDerivedPublicKey, multisigPayment } =
+        await this.createPayment(vault.uuid, attestorGroupPublicKey);
 
       const feeRate =
         customFeeRate ??
@@ -325,6 +323,8 @@ export class LedgerDLCHandler {
       const signingConfiguration = createBitcoinInputSigningConfiguration(
         fundingTransaction,
         this.walletAccountIndex,
+        this.walletAddressIndex,
+        multisigPayment,
         this.bitcoinNetwork
       );
 
@@ -353,6 +353,7 @@ export class LedgerDLCHandler {
 
         await updateTaprootInputs(
           taprootInputsToSign,
+          taprootDerivedPublicKey,
           fundingDerivedPublicKey,
           this.masterFingerprint,
           formattedFundingPSBT
@@ -374,10 +375,8 @@ export class LedgerDLCHandler {
     customFeeRate?: bigint
   ): Promise<Psbt> {
     try {
-      const { fundingPayment, taprootDerivedPublicKey, multisigPayment } = await this.createPayment(
-        vault.uuid,
-        attestorGroupPublicKey
-      );
+      const { fundingPayment, fundingDerivedPublicKey, taprootDerivedPublicKey, multisigPayment } =
+        await this.createPayment(vault.uuid, attestorGroupPublicKey);
 
       const feeRate =
         customFeeRate ??
@@ -398,6 +397,8 @@ export class LedgerDLCHandler {
       const withdrawTransactionSigningConfiguration = createBitcoinInputSigningConfiguration(
         withdrawTransaction,
         this.walletAccountIndex,
+        this.walletAddressIndex,
+        multisigPayment,
         this.bitcoinNetwork
       );
 
@@ -416,6 +417,7 @@ export class LedgerDLCHandler {
       await updateTaprootInputs(
         taprootInputsToSign,
         taprootDerivedPublicKey,
+        fundingDerivedPublicKey,
         this.masterFingerprint,
         formattedWithdrawPSBT
       );
@@ -456,6 +458,8 @@ export class LedgerDLCHandler {
     const depositTransactionSigningConfiguration = createBitcoinInputSigningConfiguration(
       depositTransaction,
       this.walletAccountIndex,
+      this.walletAddressIndex,
+      multisigPayment,
       this.bitcoinNetwork
     );
 
@@ -475,6 +479,7 @@ export class LedgerDLCHandler {
     await updateTaprootInputs(
       taprootInputsToSign,
       taprootDerivedPublicKey,
+      fundingDerivedPublicKey,
       this.masterFingerprint,
       formattedDepositPSBT
     );

--- a/src/dlc-handlers/ledger-dlc-handler.ts
+++ b/src/dlc-handlers/ledger-dlc-handler.ts
@@ -328,7 +328,8 @@ export class LedgerDLCHandler {
         this.walletAccountIndex,
         this.walletAddressIndex,
         multisigPayment,
-        this.bitcoinNetwork
+        this.bitcoinNetwork,
+        this.bitcoinNetworkIndex
       );
 
       const formattedFundingPSBT = Psbt.fromBuffer(Buffer.from(fundingTransaction.toPSBT()), {
@@ -403,7 +404,8 @@ export class LedgerDLCHandler {
         this.walletAccountIndex,
         this.walletAddressIndex,
         multisigPayment,
-        this.bitcoinNetwork
+        this.bitcoinNetwork,
+        this.bitcoinNetworkIndex
       );
 
       const formattedWithdrawPSBT = Psbt.fromBuffer(Buffer.from(withdrawTransaction.toPSBT()), {
@@ -463,7 +465,8 @@ export class LedgerDLCHandler {
       this.walletAccountIndex,
       this.walletAddressIndex,
       multisigPayment,
-      this.bitcoinNetwork
+      this.bitcoinNetwork,
+      this.bitcoinNetworkIndex
     );
 
     const formattedDepositPSBT = Psbt.fromBuffer(Buffer.from(depositTransaction.toPSBT()), {

--- a/src/dlc-handlers/ledger-dlc-handler.ts
+++ b/src/dlc-handlers/ledger-dlc-handler.ts
@@ -40,6 +40,7 @@ export class LedgerDLCHandler {
   private ledgerApp: AppClient;
   private masterFingerprint: string;
   private walletAccountIndex: number;
+  private walletAddressIndex: number;
   private fundingPaymentType: 'wpkh' | 'tr';
   private policyInformation: LedgerPolicyInformation | undefined;
   public payment: ExtendedPaymentInformation | undefined;
@@ -52,6 +53,7 @@ export class LedgerDLCHandler {
     ledgerApp: AppClient,
     masterFingerprint: string,
     walletAccountIndex: number,
+    walletAddressIndex: number,
     fundingPaymentType: 'wpkh' | 'tr',
     bitcoinNetwork: Network,
     bitcoinBlockchainAPI?: string,
@@ -89,6 +91,7 @@ export class LedgerDLCHandler {
     this.ledgerApp = ledgerApp;
     this.masterFingerprint = masterFingerprint;
     this.walletAccountIndex = walletAccountIndex;
+    this.walletAddressIndex = walletAddressIndex;
     this.fundingPaymentType = fundingPaymentType;
     this.bitcoinNetwork = bitcoinNetwork;
   }
@@ -185,13 +188,14 @@ export class LedgerDLCHandler {
         fundingWalletPolicy,
         null,
         0,
-        0,
+        this.walletAddressIndex,
         false
       );
 
       const fundingDerivedPublicKey = deriveUnhardenedPublicKey(
         fundingExtendedPublicKey,
-        this.bitcoinNetwork
+        this.bitcoinNetwork,
+        this.walletAddressIndex
       );
 
       const fundingPayment =

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -371,13 +371,12 @@ export function createBitcoinInputSigningConfiguration(
   walletAccountIndex: number,
   walletAddressIndex: number,
   multisigPayment: P2TROut,
-  bitcoinNetwork: Network
+  bitcoinNetwork: Network,
+  bitcoinNetworkIndex: number
 ): BitcoinInputSigningConfig[] {
-  const networkIndex = getBitcoinNetworkIndex(bitcoinNetwork);
-
-  const nativeSegwitDerivationPath = `m/84'/${networkIndex}'/${walletAccountIndex}'/0/${walletAddressIndex}`;
-  const taprootDerivationPath = `m/86'/${networkIndex}'/${walletAccountIndex}'/0/${walletAddressIndex}`;
-  const multisigDerivationPath = `m/86'/${networkIndex}'/${walletAccountIndex}'/0/0`;
+  const nativeSegwitDerivationPath = `m/84'/${bitcoinNetworkIndex}'/${walletAccountIndex}'/0/${walletAddressIndex}`;
+  const taprootDerivationPath = `m/86'/${bitcoinNetworkIndex}'/${walletAccountIndex}'/0/${walletAddressIndex}`;
+  const multisigDerivationPath = `m/86'/${bitcoinNetworkIndex}'/${walletAccountIndex}'/0/0`;
 
   const multisigPaymentScript = multisigPayment.script;
 
@@ -471,18 +470,6 @@ export function finalizeUserInputs(transaction: Transaction, userPayment: P2TROu
     if (inputScript && compareUint8Arrays(inputScript, userPayment.script))
       transaction.finalizeIdx(index);
   });
-}
-
-export function getBitcoinNetworkIndex(bitcoinNetwork: Network): number {
-  switch (bitcoinNetwork) {
-    case bitcoin:
-      return 0;
-    case testnet:
-    case regtest:
-      return 1;
-    default:
-      throw new Error('Unsupported Bitcoin Network');
-  }
 }
 
 /**

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -51,9 +51,11 @@ export function getFeeAmount(bitcoinAmount: number, feeBasisPoints: number): num
  */
 export function deriveUnhardenedPublicKey(
   extendedPublicKey: string,
-  bitcoinNetwork: Network
+  bitcoinNetwork: Network,
+  addressIndex: number = 0
 ): Buffer {
-  return bip32.fromBase58(extendedPublicKey, bitcoinNetwork).derivePath('0/0').publicKey;
+  return bip32.fromBase58(extendedPublicKey, bitcoinNetwork).derivePath(`0/${addressIndex}`)
+    .publicKey;
 }
 
 /**

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -58,13 +58,6 @@ export function deriveUnhardenedPublicKey(
     .publicKey;
 }
 
-export function getPublicKeyFromExtendedPublicKey(
-  extendedPublicKey: string,
-  bitcoinNetwork: Network
-): Buffer {
-  return bip32.fromBase58(extendedPublicKey, bitcoinNetwork).publicKey;
-}
-
 /**
  * Derives the Account Key Pair from the Root Private Key.
  * @param rootPrivateKey - The Root Private Key.

--- a/src/functions/bitcoin/index.ts
+++ b/src/functions/bitcoin/index.ts
@@ -3,7 +3,6 @@ import {
   getFeeAmount,
   getFeeRecipientAddressFromPublicKey,
   getInputIndicesByScript,
-  getPublicKeyFromExtendedPublicKey,
 } from '../bitcoin/bitcoin-functions.js';
 import {
   broadcastTransaction,
@@ -29,5 +28,4 @@ export {
   getBalance,
   getFeeRecipientAddressFromPublicKey,
   getInputIndicesByScript,
-  getPublicKeyFromExtendedPublicKey,
 };

--- a/src/functions/bitcoin/index.ts
+++ b/src/functions/bitcoin/index.ts
@@ -3,6 +3,7 @@ import {
   getFeeAmount,
   getFeeRecipientAddressFromPublicKey,
   getInputIndicesByScript,
+  getPublicKeyFromExtendedPublicKey,
 } from '../bitcoin/bitcoin-functions.js';
 import {
   broadcastTransaction,
@@ -28,4 +29,5 @@ export {
   getBalance,
   getFeeRecipientAddressFromPublicKey,
   getInputIndicesByScript,
+  getPublicKeyFromExtendedPublicKey,
 };

--- a/src/functions/bitcoin/psbt-functions.ts
+++ b/src/functions/bitcoin/psbt-functions.ts
@@ -411,10 +411,37 @@ export function getNativeSegwitInputsToSign(
  */
 export async function updateTaprootInputs(
   inputsToUpdate: BitcoinInputSigningConfig[] = [],
-  taprootPublicKey: Buffer,
+  multisigPublicKey: Buffer,
+  fundingPublicKey: Buffer,
   masterFingerprint: string,
   psbt: Psbt
 ): Promise<Psbt> {
+  inputsToUpdate.forEach(({ index, derivationPath, isMultisigInput }) => {
+    console.log('index', index);
+    console.log('derivationPath', derivationPath);
+    psbt.updateInput(index, {
+      tapBip32Derivation: [
+        {
+          masterFingerprint: Buffer.from(masterFingerprint, 'hex'),
+          pubkey: isMultisigInput
+            ? ecdsaPublicKeyToSchnorr(multisigPublicKey)
+            : ecdsaPublicKeyToSchnorr(fundingPublicKey),
+          path: derivationPath,
+          leafHashes: [],
+        },
+      ],
+    });
+  });
+
+  return psbt;
+}
+
+export async function updateTaprootMultisigInputs(
+  inputsToUpdate: BitcoinInputSigningConfig[] = [],
+  taprootPublicKey: Buffer,
+  masterFingerprint: string,
+  psbt: Psbt
+): Promise<void> {
   inputsToUpdate.forEach(({ index, derivationPath }) => {
     psbt.updateInput(index, {
       tapBip32Derivation: [
@@ -427,8 +454,6 @@ export async function updateTaprootInputs(
       ],
     });
   });
-
-  return psbt;
 }
 
 /**

--- a/src/functions/bitcoin/psbt-functions.ts
+++ b/src/functions/bitcoin/psbt-functions.ts
@@ -411,33 +411,6 @@ export function getNativeSegwitInputsToSign(
  */
 export async function updateTaprootInputs(
   inputsToUpdate: BitcoinInputSigningConfig[] = [],
-  multisigPublicKey: Buffer,
-  fundingPublicKey: Buffer,
-  masterFingerprint: string,
-  psbt: Psbt
-): Promise<Psbt> {
-  inputsToUpdate.forEach(({ index, derivationPath, isMultisigInput }) => {
-    console.log('index', index);
-    console.log('derivationPath', derivationPath);
-    psbt.updateInput(index, {
-      tapBip32Derivation: [
-        {
-          masterFingerprint: Buffer.from(masterFingerprint, 'hex'),
-          pubkey: isMultisigInput
-            ? ecdsaPublicKeyToSchnorr(multisigPublicKey)
-            : ecdsaPublicKeyToSchnorr(fundingPublicKey),
-          path: derivationPath,
-          leafHashes: [],
-        },
-      ],
-    });
-  });
-
-  return psbt;
-}
-
-export async function updateTaprootMultisigInputs(
-  inputsToUpdate: BitcoinInputSigningConfig[] = [],
   taprootPublicKey: Buffer,
   masterFingerprint: string,
   psbt: Psbt
@@ -514,7 +487,7 @@ async function addNativeSegwitBip32Derivation(
   masterFingerPrint: string,
   nativeSegwitPublicKey: Buffer,
   inputSigningConfiguration: BitcoinInputSigningConfig[]
-): Promise<Psbt> {
+): Promise<void> {
   inputSigningConfiguration.forEach(({ index, derivationPath }) => {
     psbt.updateInput(index, {
       bip32Derivation: [
@@ -526,8 +499,6 @@ async function addNativeSegwitBip32Derivation(
       ],
     });
   });
-
-  return psbt;
 }
 
 /**
@@ -550,25 +521,50 @@ export function addNativeSegwitSignaturesToPSBT(
  * @returns The updated PSBT.
  */
 export function addTaprootInputSignaturesToPSBT(
-  psbtType: 'funding' | 'depositWithdraw',
   psbt: Psbt,
   signatures: [number, PartialSignature][]
 ): void {
-  if (psbtType === 'funding') {
-    signatures.forEach(([index, signature]) =>
-      psbt.updateInput(index, { tapKeySig: signature.signature })
-    );
-  } else {
-    signatures.forEach(([index, signature]) =>
-      psbt.updateInput(index, {
-        tapScriptSig: [
-          {
-            signature: signature.signature,
-            pubkey: signature.pubkey,
-            leafHash: signature.tapleafHash!,
-          },
-        ],
-      })
-    );
+  signatures.forEach(([index, signature]) =>
+    psbt.updateInput(index, { tapKeySig: signature.signature })
+  );
+}
+
+export function addFundingSignaturesBasedOnPaymentType(
+  psbt: Psbt,
+  paymentType: 'wpkh' | 'tr',
+  signatures: [number, PartialSignature][]
+): void {
+  switch (paymentType) {
+    case 'wpkh':
+      addNativeSegwitSignaturesToPSBT(psbt, signatures);
+      break;
+    case 'tr':
+      addTaprootInputSignaturesToPSBT(psbt, signatures);
+      break;
+    default:
+      throw new Error('Invalid Funding Payment Type');
   }
+}
+
+/**
+ * This function updates the PSBT with the received Taproot Partial Signatures.
+ * @param psbt - The PSBT to update.
+ * @param signatures - An array of tuples containing the index of the input and the PartialSignature.
+ * @returns The updated PSBT.
+ */
+export function addTaprooMultisigInputSignaturesToPSBT(
+  psbt: Psbt,
+  signatures: [number, PartialSignature][]
+): void {
+  signatures.forEach(([index, signature]) =>
+    psbt.updateInput(index, {
+      tapScriptSig: [
+        {
+          signature: signature.signature,
+          pubkey: signature.pubkey,
+          leafHash: signature.tapleafHash!,
+        },
+      ],
+    })
+  );
 }

--- a/src/models/bitcoin-models.ts
+++ b/src/models/bitcoin-models.ts
@@ -8,6 +8,7 @@ export interface UTXO {
 }
 
 export interface BitcoinInputSigningConfig {
+  isMultisigInput: boolean;
   derivationPath: string;
   index: number;
 }


### PR DESCRIPTION
This pull request enhances the functionality of the Ledger-related functions by allowing derivation at specific address indices across different account segments in the derivation path. Previously, the functions were restricted to deriving addresses only at the default "0/0" unhardened path. With this update, users can now derive addresses at any specified index within various accounts, providing greater flexibility and control over address generation. This improvement is particularly useful for advanced use cases that require access to multiple addresses across different accounts within a Ledger wallet.