### PR TITLE
fix: modifiy getContractVaults function of EthereumHandler 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/network-handlers/ethereum-handler.ts
+++ b/src/network-handlers/ethereum-handler.ts
@@ -4,6 +4,7 @@ import {
   getAddressDLCBTCBalance,
   getAllAddressVaults,
   getAttestorGroupPublicKey,
+  getContractVaults,
   getDLCBTCTotalSupply,
   getEthereumContracts,
   getLockedBTCBalance,
@@ -139,7 +140,7 @@ export class EthereumHandler {
 
   async getContractVaults(amount: number = 50): Promise<RawVault[]> {
     try {
-      return await this.getContractVaults(amount);
+      return await getContractVaults(this.ethereumContracts.dlcManagerContract, amount);
     } catch (error) {
       throw new EthereumError(`Could not fetch All Vaults: ${error}`);
     }


### PR DESCRIPTION
This pull request fixes the ``getContractVaults()`` function of EthereumHandler. The function called itself and not the imported function.