### PR TITLE
feat: modify setup vault and withdraw to first fetch fee data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/functions/ethereum/ethereum-functions.ts
+++ b/src/functions/ethereum/ethereum-functions.ts
@@ -247,8 +247,18 @@ export async function getRawVault(
 
 export async function setupVault(dlcManagerContract: Contract): Promise<any | undefined> {
   try {
+    let transactionOptions = {};
     await dlcManagerContract.callStatic.setupVault();
-    const transaction = await dlcManagerContract.setupVault();
+    const feeData = await dlcManagerContract.provider.getFeeData();
+    const { maxPriorityFeePerGas, maxFeePerGas } = feeData;
+    if (maxPriorityFeePerGas && maxFeePerGas) {
+      transactionOptions = {
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+      };
+    }
+
+    const transaction = await dlcManagerContract.setupVault(transactionOptions);
     return await transaction.wait();
   } catch (error) {
     throw new EthereumError(`Could not Setup Vault: ${error}`);
@@ -261,8 +271,22 @@ export async function withdraw(
   withdrawAmount: bigint
 ) {
   try {
+    let transactionOptions = {};
     await dlcManagerContract.callStatic.withdraw(vaultUUID, withdrawAmount);
-    const transaction = await dlcManagerContract.withdraw(vaultUUID, withdrawAmount);
+    const feeData = await dlcManagerContract.provider.getFeeData();
+    const { maxPriorityFeePerGas, maxFeePerGas } = feeData;
+    if (maxPriorityFeePerGas && maxFeePerGas) {
+      transactionOptions = {
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+      };
+    }
+
+    const transaction = await dlcManagerContract.withdraw(
+      vaultUUID,
+      withdrawAmount,
+      transactionOptions
+    );
     return await transaction.wait();
   } catch (error) {
     throw new EthereumError(`Could not Withdraw: ${error}`);


### PR DESCRIPTION
This pull request modifes the ``setupVault`` and ``withdraw`` ethereum functions to fetch ``feeData`` before submitting the transaction. 