### PR TITLE
feat: modify software dlc handler to accept both tr and wpkh public k…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request updates the ``SoftwareWalletDLCHandler`` class to allow the ``fundingPayment`` to be either _Taproot_ or _Native SegWit_, instead of being limited to just _Native SegWit_.
