### PR TITLE
feat: add function to retrieve bitcoin address from extended public key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -481,3 +481,25 @@ export function ecdsaPublicKeyToSchnorr(publicKey: Buffer): Buffer {
     throw new Error('Invalid Public Key Length');
   return publicKey.subarray(1);
 }
+
+export function getBitcoinAddressFromExtendedPublicKey(
+  bitcoinExtendedPublicKey: string,
+  bitcoinNetwork: Network,
+  bitcoinAddressIndex: number,
+  paymentType: 'wpkh' | 'tr'
+): string {
+  const derivedPublicKey = deriveUnhardenedPublicKey(
+    bitcoinExtendedPublicKey,
+    bitcoinNetwork,
+    bitcoinAddressIndex
+  );
+
+  const bitcoinAddress =
+    paymentType === 'wpkh'
+      ? p2wpkh(derivedPublicKey, bitcoinNetwork).address
+      : p2tr(ecdsaPublicKeyToSchnorr(derivedPublicKey), undefined, bitcoinNetwork).address;
+
+  if (!bitcoinAddress) throw new Error('Could not create Bitcoin Address');
+
+  return bitcoinAddress;
+}

--- a/src/functions/bitcoin/index.ts
+++ b/src/functions/bitcoin/index.ts
@@ -1,5 +1,6 @@
 import {
   finalizeUserInputs,
+  getBitcoinAddressFromExtendedPublicKey,
   getFeeAmount,
   getFeeRecipientAddressFromPublicKey,
   getInputIndicesByScript,
@@ -28,4 +29,5 @@ export {
   getBalance,
   getFeeRecipientAddressFromPublicKey,
   getInputIndicesByScript,
+  getBitcoinAddressFromExtendedPublicKey,
 };


### PR DESCRIPTION
This pull request introduces a function to retrieve a _Taproot_ or _Native Segwit_ address from an _Extended Public Key_.