### PR TITLE
feat: ibtc/integrationAddress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.4.10",
+  "version": "2.4.12",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/ripple.constants.ts
+++ b/src/constants/ripple.constants.ts
@@ -1,4 +1,4 @@
 import { convertStringToHex } from 'xrpl';
 
 export const TRANSACTION_SUCCESS_CODE = 'tesSUCCESS';
-export const XRPL_DLCBTC_CURRENCY_HEX = convertStringToHex('dlcBTC').padEnd(40, '0');
+export const XRPL_DLCBTC_CURRENCY_HEX = convertStringToHex('iBTC').padEnd(40, '0');

--- a/src/functions/ripple/ripple.functions.ts
+++ b/src/functions/ripple/ripple.functions.ts
@@ -98,6 +98,7 @@ export function decodeURI(URI: string): RawVault {
       btcFeeRecipient: URI.slice(332, 398),
       taprootPubKey: URI.slice(398, 462),
       closingTxId: '', // Deprecated
+      icyIntegrationAddress: '', // not used in xrpl
     };
   } catch (error) {
     throw new Error(`Could not decode NFT URI: ${error}`);

--- a/src/models/ethereum-models.ts
+++ b/src/models/ethereum-models.ts
@@ -40,6 +40,7 @@ export interface RawVault {
   btcMintFeeBasisPoints: BigNumber;
   btcRedeemFeeBasisPoints: BigNumber;
   taprootPubKey: string;
+  icyIntegrationAddress: string;
 }
 
 export interface SSPVaultUpdate {

--- a/src/network-handlers/ripple-handler.ts
+++ b/src/network-handlers/ripple-handler.ts
@@ -47,6 +47,7 @@ function buildDefaultNftVault(): RawVault {
     btcMintFeeBasisPoints: BigNumber.from(100),
     btcRedeemFeeBasisPoints: BigNumber.from(100),
     taprootPubKey: '0'.repeat(64),
+    icyIntegrationAddress: '',
   };
 }
 

--- a/src/network-handlers/ripple-handler.ts
+++ b/src/network-handlers/ripple-handler.ts
@@ -1,11 +1,5 @@
 import { Decimal } from 'decimal.js';
 import { BigNumber } from 'ethers';
-import {
-  AutoFillValues,
-  MultisignatureTransactionResponse,
-  SignResponse,
-  XRPLSignatures,
-} from 'src/models/ripple.model.js';
 import xrpl, {
   AccountNFTsRequest,
   AccountObject,
@@ -29,6 +23,12 @@ import {
 } from '../functions/ripple/ripple.functions.js';
 import { RippleError } from '../models/errors.js';
 import { RawVault, SSFVaultUpdate, SSPVaultUpdate } from '../models/ethereum-models.js';
+import {
+  AutoFillValues,
+  MultisignatureTransactionResponse,
+  SignResponse,
+  XRPLSignatures,
+} from '../models/ripple.model.js';
 import { shiftValue, unshiftValue } from '../utilities/index.js';
 
 function buildDefaultNftVault(): RawVault {

--- a/tests/mocks/ethereum-vault.test.constants.ts
+++ b/tests/mocks/ethereum-vault.test.constants.ts
@@ -17,6 +17,7 @@ export const TEST_VAULT_1: RawVault = {
   btcMintFeeBasisPoints: BigNumber.from('0x64'),
   btcRedeemFeeBasisPoints: BigNumber.from('0x64'),
   taprootPubKey: '',
+  icyIntegrationAddress: '',
 };
 
 export const TEST_VAULT_2: RawVault = {
@@ -34,6 +35,7 @@ export const TEST_VAULT_2: RawVault = {
   btcMintFeeBasisPoints: BigNumber.from('0x64'),
   btcRedeemFeeBasisPoints: BigNumber.from('0x64'),
   taprootPubKey: 'dc544c17af0887dfc8ca9936755c9fdef0c79bbc8866cd69bf120c71509742d2',
+  icyIntegrationAddress: '',
 };
 
 export const TEST_VAULT_3: RawVault = {
@@ -51,4 +53,5 @@ export const TEST_VAULT_3: RawVault = {
   btcMintFeeBasisPoints: BigNumber.from('0x64'),
   btcRedeemFeeBasisPoints: BigNumber.from('0x64'),
   taprootPubKey: 'b362931e3e4cf3cc20f75ae11ff5a4c115ec1548cb5f2c7c48294929f1e8979c',
+  icyIntegrationAddress: '',
 };


### PR DESCRIPTION
This PR updates the library by changing the XRPL currency name to iBTC. It also modifies the RawVault object to include icyIntegrationAddress field.