### PR TITLE
Feat/updated fee address tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.4.2",
+  "version": "2.4.20",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.4.19",
+  "version": "2.4.2",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -12,7 +12,7 @@ import {
 import { P2Ret, P2TROut } from '@scure/btc-signer/payment';
 import { TransactionInput } from '@scure/btc-signer/psbt';
 import { BIP32Factory, BIP32Interface } from 'bip32';
-import { Network, address } from 'bitcoinjs-lib';
+import { Network, address, initEccLib } from 'bitcoinjs-lib';
 import { bitcoin, regtest, testnet } from 'bitcoinjs-lib/src/networks.js';
 import { Decimal } from 'decimal.js';
 import * as ellipticCurveCryptography from 'tiny-secp256k1';
@@ -37,6 +37,7 @@ const TAPROOT_UNSPENDABLE_KEY_HEX =
 const ECDSA_PUBLIC_KEY_LENGTH = 33;
 
 const bip32 = BIP32Factory(ellipticCurveCryptography);
+initEccLib(ellipticCurveCryptography);
 
 export function getFeeAmount(bitcoinAmount: number, feeBasisPoints: number): number {
   const feePercentage = new Decimal(feeBasisPoints).dividedBy(10000);

--- a/tests/unit/bitcoin-functions.test.ts
+++ b/tests/unit/bitcoin-functions.test.ts
@@ -13,7 +13,6 @@ import {
   getScriptMatchingOutputFromTransaction,
   getUnspendableKeyCommittedToUUID,
 } from '../../src/functions/bitcoin/bitcoin-functions';
-import { shiftValue, unshiftValue } from '../../src/utilities';
 import {
   TEST_TESTNET_ATTESTOR_EXTENDED_GROUP_PUBLIC_KEY_1,
   TEST_TESTNET_ATTESTOR_UNHARDENED_DERIVED_PUBLIC_KEY_1,
@@ -83,6 +82,11 @@ describe('Bitcoin Functions', () => {
         expect(getFeeRecipientAddress(address, network)).toBe(address);
       });
 
+      it('accepts nested segwit (p2sh) address', () => {
+        const address = '3KF9nXowQ4asSGxRRzeiTpDjMuwM2nypAN';
+        expect(getFeeRecipientAddress(address, network)).toBe(address);
+      });
+
       it('converts public key to native segwit address', () => {
         const publicKey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
         const expectedAddress = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
@@ -103,6 +107,11 @@ describe('Bitcoin Functions', () => {
         expect(getFeeRecipientAddress(address, network)).toBe(address);
       });
 
+      it('accepts nested segwit (p2sh) address', () => {
+        const address = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
+        expect(getFeeRecipientAddress(address, network)).toBe(address);
+      });
+
       it('converts public key to native segwit address', () => {
         const publicKey = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
         const expectedAddress = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
@@ -120,6 +129,11 @@ describe('Bitcoin Functions', () => {
 
       it('accepts taproot (p2tr) address', () => {
         const address = 'bcrt1qqhy33peyp82mf82fktdtphfmnhtxyhtpc0u653';
+        expect(getFeeRecipientAddress(address, network)).toBe(address);
+      });
+
+      it('accepts nested segwit (p2sh) address', () => {
+        const address = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
         expect(getFeeRecipientAddress(address, network)).toBe(address);
       });
 

--- a/tests/unit/bitcoin-functions.test.ts
+++ b/tests/unit/bitcoin-functions.test.ts
@@ -78,7 +78,7 @@ describe('Bitcoin Functions', () => {
       });
 
       it('accepts taproot (p2tr) address', () => {
-        const address = 'bc1qw02rsw9afgp4dsd5n87z5s6rqnf455yhhsnz9f';
+        const address = 'bc1pgj9ef0lhysgd2v042jta4mv8qmc70yappkv7vpl76dhfvrdfvusqqe4qj3';
         expect(getFeeRecipientAddress(address, network)).toBe(address);
       });
 
@@ -103,7 +103,7 @@ describe('Bitcoin Functions', () => {
       });
 
       it('accepts taproot (p2tr) address', () => {
-        const address = 'tb1qqhy33peyp82mf82fktdtphfmnhtxyhtp6x9hrc';
+        const address = 'tb1pa8hxt6r2gkc8d5thzfrw7gyrqlv354rdy4k05ylkvf6nadnhg8xsygyusf';
         expect(getFeeRecipientAddress(address, network)).toBe(address);
       });
 
@@ -128,7 +128,7 @@ describe('Bitcoin Functions', () => {
       });
 
       it('accepts taproot (p2tr) address', () => {
-        const address = 'bcrt1qqhy33peyp82mf82fktdtphfmnhtxyhtpc0u653';
+        const address = 'bcrt1pa8hxt6r2gkc8d5thzfrw7gyrqlv354rdy4k05ylkvf6nadnhg8xsf3w69n';
         expect(getFeeRecipientAddress(address, network)).toBe(address);
       });
 


### PR DESCRIPTION
This PR introduces validation cases for ``NestedSegwit`` addresses in the ``getFeeRecipient()`` function tests. It also corrects instances where ``NativeSegwit`` addresses were mistakenly used by replacing them with ``Taproot`` addresses where appropriate. Additionally, it incorporates the use of ``initEccLib()`` in the ``bitcoin-functions`` file, enabling the ``getFeeRecipient()`` function to generate output scripts for ``Taproot`` addresses correctly.