### PR TITLE
feat: modify fee rate fetching by adding complex logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # dlc-btc-lib
 
 **dlc-btc-lib** is a comprehensive library for interacting with DLC.Link smart contracts and the Bitcoin blockchain. It includes functions for creating valid Partially Signed Bitcoin Transactions, handling setup, deposit, and withdrawal interactions, and interfacing with Attestors. This library provides all the essential tools and utilities for seamless blockchain and smart contract interactions.
+
+## Fee Rate Calculation
+
+The transaction fee rate is calculated by taking the maximum value among three metrics from the Bitcoin blockchain:
+
+- Average fee rate from the last two blocks
+- Current mempool block's median fee rate
+- Estimated "fastest" fee rate
+
+Each metric is adjusted by an optional multiplier (defaults to 1.0) and the final result is rounded up to the nearest whole number. For regtest environments, a fixed fee rate of 2 is used.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 The transaction fee rate is calculated by taking the maximum value among three metrics from the Bitcoin blockchain:
 
-- Average fee rate from the last two blocks
-- Current mempool block's median fee rate
-- Estimated "fastest" fee rate
+- Average fee rate from the last two blocks `/api/v1/mining/blocks/fee-rates/24h`
+- Current mempool block's median fee rate `/api/v1/fees/mempool-blocks`
+- Recommended "fastest" fee rate by API `/api/v1/fees/recommended`
 
 Each metric is adjusted by an optional multiplier (defaults to 1.0) and the final result is rounded up to the nearest whole number. For regtest environments, a fixed fee rate of 2 is used.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dlc-handlers/abstract-dlc-handler.ts
+++ b/src/dlc-handlers/abstract-dlc-handler.ts
@@ -1,6 +1,7 @@
 import { Transaction } from '@scure/btc-signer';
 import { P2Ret, P2TROut } from '@scure/btc-signer/payment';
 import { Network } from 'bitcoinjs-lib';
+import { regtest } from 'bitcoinjs-lib/src/networks.js';
 
 import {
   createNativeSegwitPayment,
@@ -133,11 +134,16 @@ export abstract class AbstractDLCHandler {
     }
   }
 
-  private async getFeeRate(feeRateMultiplier?: number, customFeeRate?: bigint): Promise<bigint> {
-    return (
-      customFeeRate ??
-      BigInt(await getFeeRate(this.bitcoinBlockchainFeeRecommendationAPI, feeRateMultiplier))
-    );
+  protected async getFeeRate(feeRateMultiplier?: number, customFeeRate?: bigint): Promise<bigint> {
+    if (customFeeRate) {
+      return customFeeRate;
+    }
+
+    if (this.bitcoinNetwork === regtest) {
+      return BigInt(2);
+    }
+
+    return BigInt(await getFeeRate(this.bitcoinBlockchainFeeRecommendationAPI, feeRateMultiplier));
   }
 
   async createFundingPSBT(

--- a/src/dlc-handlers/ledger-dlc-handler.ts
+++ b/src/dlc-handlers/ledger-dlc-handler.ts
@@ -10,7 +10,6 @@ import {
   deriveUnhardenedPublicKey,
   ecdsaPublicKeyToSchnorr,
   getBalance,
-  getFeeRate,
   getInputByPaymentTypeArray,
   getUnspendableKeyCommittedToUUID,
 } from '../functions/bitcoin/bitcoin-functions.js';
@@ -246,9 +245,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
         attestorGroupPublicKey
       );
 
-      const feeRate =
-        customFeeRate ??
-        BigInt(await getFeeRate(this.bitcoinBlockchainFeeRecommendationAPI, feeRateMultiplier));
+      const feeRate = await this.getFeeRate(feeRateMultiplier, customFeeRate);
 
       const addressBalance = await getBalance(fundingPayment, this.bitcoinBlockchainAPI);
 
@@ -327,9 +324,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
         attestorGroupPublicKey
       );
 
-      const feeRate =
-        customFeeRate ??
-        BigInt(await getFeeRate(this.bitcoinBlockchainFeeRecommendationAPI, feeRateMultiplier));
+      const feeRate = await this.getFeeRate(feeRateMultiplier, customFeeRate);
 
       const withdrawTransaction = await createWithdrawTransaction(
         this.bitcoinBlockchainAPI,
@@ -388,9 +383,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
     const { fundingPayment, taprootDerivedPublicKey, fundingDerivedPublicKey, multisigPayment } =
       await this.createPayment(vault.uuid, attestorGroupPublicKey);
 
-    const feeRate =
-      customFeeRate ??
-      BigInt(await getFeeRate(this.bitcoinBlockchainFeeRecommendationAPI, feeRateMultiplier));
+    const feeRate = await this.getFeeRate(feeRateMultiplier, customFeeRate);
 
     const depositTransaction = await createDepositTransaction(
       this.bitcoinBlockchainAPI,

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -226,17 +226,19 @@ export async function getFeeRate(
     getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL),
   ]);
 
-  const currentBlockFeeRateMultiplied = Math.ceil(currentBlockFeeRate) * multiplier;
+  const currentBlockFeeRateMultiplied = currentBlockFeeRate * multiplier;
 
   const lastTwoBlocksfeeRateAverageMultiplied =
     (lastTwoBlocksFeeRate.reduce((a, b) => a + b) / lastTwoBlocksFeeRate.length) * multiplier;
 
   const estimatedFeeRateMultiplied = estimatedFeeRate * multiplier;
 
-  return Math.max(
-    lastTwoBlocksfeeRateAverageMultiplied,
-    currentBlockFeeRateMultiplied,
-    estimatedFeeRateMultiplied
+  return Math.ceil(
+    Math.max(
+      lastTwoBlocksfeeRateAverageMultiplied,
+      currentBlockFeeRateMultiplied,
+      estimatedFeeRateMultiplied
+    )
   );
 }
 

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -220,15 +220,17 @@ export async function getFeeRate(
 
   const multiplier = feeRateMultiplier ?? 1;
 
-  const currentBlockFeeRate = await getCurrentMempoolBlockFeeRate(bitcoinBlockchainAPIFeeURL);
+  const [lastTwoBlocksFeeRate, currentBlockFeeRate, estimatedFeeRate] = await Promise.all([
+    getLastTwoBlocksFeeRate(bitcoinBlockchainAPIFeeURL),
+    getCurrentMempoolBlockFeeRate(bitcoinBlockchainAPIFeeURL),
+    getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL),
+  ]);
+
   const currentBlockFeeRateMultiplied = Math.ceil(currentBlockFeeRate) * multiplier;
 
-  const lastTwoBlocksFeeRate = await getLastTwoBlocksFeeRate(bitcoinBlockchainAPIFeeURL);
-  const lastTwoBlocksfeeRateAverage =
-    lastTwoBlocksFeeRate.reduce((a, b) => a + b) / lastTwoBlocksFeeRate.length;
-  const lastTwoBlocksfeeRateAverageMultiplied = Math.ceil(lastTwoBlocksfeeRateAverage) * multiplier;
+  const lastTwoBlocksfeeRateAverageMultiplied =
+    (lastTwoBlocksFeeRate.reduce((a, b) => a + b) / lastTwoBlocksFeeRate.length) * multiplier;
 
-  const estimatedFeeRate = await getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL);
   const estimatedFeeRateMultiplied = estimatedFeeRate * multiplier;
 
   return Math.max(

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -221,18 +221,21 @@ export async function getFeeRate(
   const multiplier = feeRateMultiplier ?? 1;
 
   const currentBlockFeeRate = await getCurrentMempoolBlockFeeRate(bitcoinBlockchainAPIFeeURL);
-  const lastTwoBlocksFeeRate = await getLastTwoBlocksFeeRate(bitcoinBlockchainAPIFeeURL);
+  const currentBlockFeeRateMultiplied = Math.ceil(currentBlockFeeRate) * multiplier;
 
-  const feeRates = lastTwoBlocksFeeRate.concat(currentBlockFeeRate);
-  const feeRateAverage = feeRates.reduce((a, b) => a + b) / feeRates.length;
-  const feeRateAverageMultiplied = Math.ceil(feeRateAverage) * multiplier;
-  console.log('Fee Rate Average Multiplied:', feeRateAverageMultiplied);
+  const lastTwoBlocksFeeRate = await getLastTwoBlocksFeeRate(bitcoinBlockchainAPIFeeURL);
+  const lastTwoBlocksfeeRateAverage =
+    lastTwoBlocksFeeRate.reduce((a, b) => a + b) / lastTwoBlocksFeeRate.length;
+  const lastTwoBlocksfeeRateAverageMultiplied = Math.ceil(lastTwoBlocksfeeRateAverage) * multiplier;
 
   const estimatedFeeRate = await getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL);
   const estimatedFeeRateMultiplied = estimatedFeeRate * multiplier;
-  console.log('Estimated Fee Rate Multiplied:', estimatedFeeRateMultiplied);
 
-  return Math.max(feeRateAverageMultiplied, estimatedFeeRateMultiplied);
+  return Math.max(
+    lastTwoBlocksfeeRateAverageMultiplied,
+    currentBlockFeeRateMultiplied,
+    estimatedFeeRateMultiplied
+  );
 }
 
 /**

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -21,7 +21,9 @@ import {
   BitcoinInputSigningConfig,
   BitcoinTransaction,
   BitcoinTransactionVectorOutput,
+  BlockData,
   FeeRates,
+  HistoricalFeeRate,
   PaymentTypes,
   UTXO,
 } from '../../models/bitcoin-models.js';
@@ -143,44 +145,94 @@ export function createTaprootMultisigPayment(
 }
 
 /**
- * Evaluates the fee rate from the bitcoin blockchain API.
+ * Fetches the last two blocks' fee rates from the bitcoin blockchain API.
  *
- * @returns The fee rate.
+ * @returns A promise that resolves to the last two blocks' median fee rates.
  */
-function checkFeeRate(feeRate: number | undefined): number {
-  if (!feeRate || feeRate < 2) {
-    return 2;
-  }
-  return feeRate;
-}
+export async function getLastTwoBlocksFeeRate(
+  bitcoinBlockchainAPIFeeURL: string
+): Promise<number[]> {
+  const dayFeeRateAPI = `${bitcoinBlockchainAPIFeeURL}/api/v1/mining/blocks/fee-rates/24h`;
 
-/**
- * Fetches the fee rate from the bitcoin blockchain API.
- *
- * @returns A promise that resolves to the hour fee rate.
- */
-export async function getFeeRate(
-  bitcoinBlockchainAPIFeeURL: string,
-  feeRateMultiplier?: number
-): Promise<number> {
-  const response = await fetch(bitcoinBlockchainAPIFeeURL);
+  const response = await fetch(dayFeeRateAPI);
 
   if (!response.ok) {
     throw new Error(`Bitcoin Blockchain Fee Rate Response was not OK: ${response.statusText}`);
   }
 
-  let feeRates: FeeRates;
+  const historicalFeeRates: HistoricalFeeRate[] = await response.json();
 
-  try {
-    feeRates = await response.json();
-  } catch (error) {
-    throw new Error(`Error parsing Bitcoin Blockchain Fee Rate Response JSON: ${error}`);
+  return historicalFeeRates.slice(historicalFeeRates.length - 2).map(rate => rate.avgFee_50);
+}
+
+/**
+ * Fetches the current mempool block median fee rate from the bitcoin blockchain API.
+ *
+ * @param bitcoinBlockchainAPIFeeURL
+ * @returns
+ */
+export async function getCurrentMempoolBlockFeeRate(
+  bitcoinBlockchainAPIFeeURL: string
+): Promise<number> {
+  const mempoolBlocksAPI = `${bitcoinBlockchainAPIFeeURL}/api/v1/fees/mempool-blocks`;
+
+  const response = await fetch(mempoolBlocksAPI);
+
+  if (!response.ok) {
+    throw new Error(`Bitcoin Blockchain Fee Rate Response was not OK: ${response.statusText}`);
   }
 
-  const feeRate = checkFeeRate(feeRates.fastestFee);
-  const multipliedFeeRate = feeRate * (feeRateMultiplier ?? 1);
+  const currentBlockFeeRate: BlockData[] = await response.json();
 
-  return multipliedFeeRate;
+  return currentBlockFeeRate[0].medianFee;
+}
+
+/**
+ * Fetches the estimated fee rate from the bitcoin blockchain API.
+ *
+ * @returns A promise that resolves to the fastest fee rate.
+ */
+export async function getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL: string): Promise<number> {
+  const estimatedFeeAPI = `${bitcoinBlockchainAPIFeeURL}/api/v1/fees/recommended`;
+
+  const response = await fetch(estimatedFeeAPI);
+
+  if (!response.ok) {
+    throw new Error(`Bitcoin Blockchain Fee Rate Response was not OK: ${response.statusText}`);
+  }
+
+  const feeRates: FeeRates = await response.json();
+
+  return feeRates.fastestFee;
+}
+
+/**
+ * Return the fee rate for the transaction.
+ *
+ * @returns A promise that resolves to the fee rate.
+ */
+export async function getFeeRate(
+  bitcoinBlockchainAPIFeeURL: string,
+  feeRateMultiplier?: number,
+  isRegtest = false
+): Promise<number> {
+  if (isRegtest) return 2;
+
+  const multiplier = feeRateMultiplier ?? 1;
+
+  const currentBlockFeeRate = await getCurrentMempoolBlockFeeRate(bitcoinBlockchainAPIFeeURL);
+  const lastTwoBlocksFeeRate = await getLastTwoBlocksFeeRate(bitcoinBlockchainAPIFeeURL);
+
+  const feeRates = lastTwoBlocksFeeRate.concat(currentBlockFeeRate);
+  const feeRateAverage = feeRates.reduce((a, b) => a + b) / feeRates.length;
+  const feeRateAverageMultiplied = Math.ceil(feeRateAverage) * multiplier;
+  console.log('Fee Rate Average Multiplied:', feeRateAverageMultiplied);
+
+  const estimatedFeeRate = await getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL);
+  const estimatedFeeRateMultiplied = estimatedFeeRate * multiplier;
+  console.log('Estimated Fee Rate Multiplied:', estimatedFeeRateMultiplied);
+
+  return Math.max(feeRateAverageMultiplied, estimatedFeeRateMultiplied);
 }
 
 /**

--- a/src/functions/bitcoin/bitcoin-functions.ts
+++ b/src/functions/bitcoin/bitcoin-functions.ts
@@ -213,12 +213,10 @@ export async function getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL: string): P
  */
 export async function getFeeRate(
   bitcoinBlockchainAPIFeeURL: string,
-  feeRateMultiplier?: number,
+  feeRateMultiplier = 1,
   isRegtest = false
 ): Promise<number> {
   if (isRegtest) return 2;
-
-  const multiplier = feeRateMultiplier ?? 1;
 
   const [lastTwoBlocksFeeRate, currentBlockFeeRate, estimatedFeeRate] = await Promise.all([
     getLastTwoBlocksFeeRate(bitcoinBlockchainAPIFeeURL),
@@ -226,12 +224,13 @@ export async function getFeeRate(
     getEstimatedFeeRate(bitcoinBlockchainAPIFeeURL),
   ]);
 
-  const currentBlockFeeRateMultiplied = currentBlockFeeRate * multiplier;
+  const currentBlockFeeRateMultiplied = currentBlockFeeRate * feeRateMultiplier;
 
   const lastTwoBlocksfeeRateAverageMultiplied =
-    (lastTwoBlocksFeeRate.reduce((a, b) => a + b) / lastTwoBlocksFeeRate.length) * multiplier;
+    (lastTwoBlocksFeeRate.reduce((a, b) => a + b) / lastTwoBlocksFeeRate.length) *
+    feeRateMultiplier;
 
-  const estimatedFeeRateMultiplied = estimatedFeeRate * multiplier;
+  const estimatedFeeRateMultiplied = estimatedFeeRate * feeRateMultiplier;
 
   return Math.ceil(
     Math.max(

--- a/src/models/bitcoin-models.ts
+++ b/src/models/bitcoin-models.ts
@@ -21,6 +21,27 @@ export interface FeeRates {
   minimumFee: number;
 }
 
+export interface BlockData {
+  blockSize: number;
+  blockVSize: number;
+  nTx: number;
+  totalFees: number;
+  medianFee: number;
+  feeRange: number[];
+}
+
+export interface HistoricalFeeRate {
+  avgHeight: number;
+  timestamp: number;
+  avgFee_0: number;
+  avgFee_10: number;
+  avgFee_25: number;
+  avgFee_50: number;
+  avgFee_75: number;
+  avgFee_90: number;
+  avgFee_100: number;
+}
+
 export interface PaymentInformation {
   fundingPayment: P2Ret | P2TROut;
   multisigPayment: P2TROut;

--- a/tests/unit/bitcoin-functions.test.ts
+++ b/tests/unit/bitcoin-functions.test.ts
@@ -40,12 +40,6 @@ import {
 import { TEST_VAULT_UUID_1 } from '../mocks/ethereum.test.constants';
 
 describe('Bitcoin Functions', () => {
-  describe('getFeeRate', () => {
-    it('should return the fee rate in satoshis per byte', async () => {
-      const feeRate = await getFeeRate('https://mempool.space');
-      console.log(feeRate);
-    }, 30000);
-  });
   describe('getInputIndicesByScript', () => {
     it('correctly retrieves one input index by script', () => {
       const transaction = Transaction.fromPSBT(

--- a/tests/unit/bitcoin-functions.test.ts
+++ b/tests/unit/bitcoin-functions.test.ts
@@ -8,7 +8,6 @@ import {
   ecdsaPublicKeyToSchnorr,
   finalizeUserInputs,
   getFeeAmount,
-  getFeeRate,
   getFeeRecipientAddress,
   getInputIndicesByScript,
   getScriptMatchingOutputFromTransaction,

--- a/tests/unit/bitcoin-functions.test.ts
+++ b/tests/unit/bitcoin-functions.test.ts
@@ -8,6 +8,7 @@ import {
   ecdsaPublicKeyToSchnorr,
   finalizeUserInputs,
   getFeeAmount,
+  getFeeRate,
   getFeeRecipientAddress,
   getInputIndicesByScript,
   getScriptMatchingOutputFromTransaction,
@@ -39,6 +40,12 @@ import {
 import { TEST_VAULT_UUID_1 } from '../mocks/ethereum.test.constants';
 
 describe('Bitcoin Functions', () => {
+  describe('getFeeRate', () => {
+    it('should return the fee rate in satoshis per byte', async () => {
+      const feeRate = await getFeeRate('https://mempool.space');
+      console.log(feeRate);
+    }, 30000);
+  });
   describe('getInputIndicesByScript', () => {
     it('correctly retrieves one input index by script', () => {
       const transaction = Transaction.fromPSBT(


### PR DESCRIPTION
This PR updates the fee rate fetching logic to avoid relying solely on the fee estimation endpoint as the source of truth. Instead, it retrieves the fee rates for the next block and the previous two blocks, calculates their average, and returns the higher value between the estimation and the three-block average.