### PR TITLE
feat: add avalanche and bsc blockchains as supported blockchains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/ethereum-constants.ts
+++ b/src/constants/ethereum-constants.ts
@@ -53,6 +53,20 @@ const ethereumHardhat: EthereumNetwork = {
   defaultNodeURL: 'http://localhost:8545',
 };
 
+const ethereumAvalanche: EthereumNetwork = {
+  name: 'Avax',
+  displayName: 'Avalanche',
+  id: EthereumNetworkID.Avalanche,
+  defaultNodeURL: 'https://api.avax.network/ext/bc/C/rpc',
+};
+
+const ethereumBSC: EthereumNetwork = {
+  name: 'BSC',
+  displayName: 'Binace Smart Chain',
+  id: EthereumNetworkID.BSC,
+  defaultNodeURL: 'https://rpc.ankr.com/bsc',
+};
+
 export const supportedEthereumNetworks: EthereumNetwork[] = [
   ethereumArbitrumSepolia,
   ethereumArbitrum,
@@ -60,6 +74,8 @@ export const supportedEthereumNetworks: EthereumNetwork[] = [
   ethereumSepolia,
   ethereumBase,
   ethereumBaseSepolia,
+  ethereumAvalanche,
+  ethereumBSC,
   ethereumHardhat,
 ];
 

--- a/src/models/attestor.models.ts
+++ b/src/models/attestor.models.ts
@@ -9,6 +9,8 @@ export type AttestorChainID =
   | 'evm-opsepolia'
   | 'evm-polygon'
   | 'evm-polygonsepolia'
+  | 'evm-avax'
+  | 'evm-bsc'
   | 'evm-localhost'
   | 'evm-hardhat-arb'
   | 'evm-hardhat-eth'

--- a/src/models/ethereum-models.ts
+++ b/src/models/ethereum-models.ts
@@ -11,6 +11,8 @@ export enum EthereumNetworkID {
   Mainnet = '1',
   Sepolia = '11155111',
   Arbitrum = '42161',
+  Avalanche = '43114',
+  BSC = '56',
   ArbitrumSepolia = '421614',
   Base = '8453',
   BaseSepolia = '84532',


### PR DESCRIPTION
This PR introduces support for the Avalanche and BSC blockchains, adding their respective information.