### PR TITLE
fix: modify getNFTokenID function to return newest nft

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/functions/ripple/ripple.functions.ts
+++ b/src/functions/ripple/ripple.functions.ts
@@ -310,15 +310,16 @@ export async function getNFTokenIDForVault(
   vaultUUID: string
 ): Promise<string> {
   try {
-    const allNFTs = await getAllIssuerNFTs(xrplClient, issuerAddress);
-    const matchingNFTs = allNFTs.filter(nft => decodeURI(nft.URI!).uuid.slice(2) === vaultUUID);
+    const nftID = (await getAllIssuerNFTs(xrplClient, issuerAddress))
+      .filter(nft => decodeURI(nft.URI!).uuid.slice(2) === vaultUUID)
+      .sort((a, b) => b.nft_serial - a.nft_serial)
+      .at(0)?.NFTokenID;
 
-    if (matchingNFTs.length === 0) {
+    if (!nftID) {
       throw new RippleError(`Could not find matching NFT for Vault: ${vaultUUID}`);
     }
 
-    const sortedNFTs = matchingNFTs.sort((a, b) => b.nft_serial - a.nft_serial);
-    return sortedNFTs[0].NFTokenID;
+    return nftID;
   } catch (error) {
     throw new RippleError(`Could not find NFTokenID for Vault: ${error}`);
   }

--- a/src/functions/ripple/ripple.functions.ts
+++ b/src/functions/ripple/ripple.functions.ts
@@ -297,14 +297,14 @@ export async function getAllIssuerNFTs(
 }
 
 /**
- * Gets the NFTokenID of the oldest NFT (lowest serial number) for a given Vault UUID
+ * Gets the NFTokenID of an NFT for a given Vault UUID
  * @param xrplClient - Connected XRPL Client instance
  * @param issuerAddress - Address of the NFT issuer
  * @param vaultUUID - UUID of the Vault to search for
  * @returns NFTokenID string from XRPL network
  * @throws RippleError if matching Vault not found or operation fails
  */
-export async function getSecondToNewestNFTokenIDForVault(
+export async function getNFTokenIDForVault(
   xrplClient: Client,
   issuerAddress: string,
   vaultUUID: string
@@ -313,15 +313,12 @@ export async function getSecondToNewestNFTokenIDForVault(
     const allNFTs = await getAllIssuerNFTs(xrplClient, issuerAddress);
     const matchingNFTs = allNFTs.filter(nft => decodeURI(nft.URI!).uuid.slice(2) === vaultUUID);
 
-    switch (matchingNFTs.length) {
-      case 0:
-        throw new RippleError(`Vault ${vaultUUID} not found`);
-      case 1:
-        throw new RippleError(`Vault ${vaultUUID} has only one NFT, no older duplicates found`);
+    if (matchingNFTs.length === 0) {
+      throw new RippleError(`Could not find matching NFT for Vault: ${vaultUUID}`);
     }
 
     const sortedNFTs = matchingNFTs.sort((a, b) => b.nft_serial - a.nft_serial);
-    return sortedNFTs[1].NFTokenID;
+    return sortedNFTs[0].NFTokenID;
   } catch (error) {
     throw new RippleError(`Could not find NFTokenID for Vault: ${error}`);
   }

--- a/src/network-handlers/ripple-handler.ts
+++ b/src/network-handlers/ripple-handler.ts
@@ -22,8 +22,8 @@ import {
   encodeURI,
   getAllXRPLVaults,
   getCheckByTXHash,
+  getNFTokenIDForVault,
   getRippleVault,
-  getSecondToNewestNFTokenIDForVault,
   multiSignTransaction,
   submitMultiSignedXRPLTransaction,
 } from '../functions/ripple/ripple.functions.js';
@@ -397,11 +397,7 @@ export class RippleHandler {
     return await this.withConnectionMgmt(async () => {
       try {
         console.log(`Getting sig for Burning Ripple Vault, vault: ${nftUUID}`);
-        const nftTokenId = await getSecondToNewestNFTokenIDForVault(
-          this.client,
-          this.issuerAddress,
-          nftUUID
-        );
+        const nftTokenId = await getNFTokenIDForVault(this.client, this.issuerAddress, nftUUID);
 
         const burnTransactionJson: SubmittableTransaction = {
           TransactionType: 'NFTokenBurn',


### PR DESCRIPTION
This PR updates the `getSecondToNewestNFTokenIDForVault` function to return the newest NFT's Token ID instead of the second newest. The function has also been renamed to `getNFTokenIDForVault`. Previously, it was incorrectly assumed that multiple NFTs would exist at this point. However, since the minting process to update the NFT has not occurred yet, there should only be one NFT at this stage.