### PR TITLE
fix: correct typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/ethereum-constants.ts
+++ b/src/constants/ethereum-constants.ts
@@ -62,7 +62,7 @@ const ethereumAvalanche: EthereumNetwork = {
 
 const ethereumBSC: EthereumNetwork = {
   name: 'BSC',
-  displayName: 'Binace Smart Chain',
+  displayName: 'Binance Smart Chain',
   id: EthereumNetworkID.BSC,
   defaultNodeURL: 'https://rpc.ankr.com/bsc',
 };


### PR DESCRIPTION
This pull request includes a small correction in the `src/constants/ethereum-constants.ts` file. The change fixes a typo in the display name of the Binance Smart Chain.

