### PR TITLE
feat: replace fee recipient argument source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.5.10",
+  "version": "2.5.11",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dlc-handlers/abstract-dlc-handler.ts
+++ b/src/dlc-handlers/abstract-dlc-handler.ts
@@ -150,6 +150,7 @@ export abstract class AbstractDLCHandler {
     vault: RawVault,
     depositAmount: bigint,
     attestorGroupPublicKey: string,
+    feeRecipient: string,
     feeRateMultiplier?: number,
     customFeeRate?: bigint
   ): Promise<Transaction> {
@@ -169,7 +170,7 @@ export abstract class AbstractDLCHandler {
       multisigPayment,
       fundingPayment,
       feeRate,
-      vault.btcFeeRecipient,
+      feeRecipient,
       vault.btcMintFeeBasisPoints.toBigInt()
     );
   }
@@ -179,6 +180,7 @@ export abstract class AbstractDLCHandler {
     withdrawAmount: bigint,
     attestorGroupPublicKey: string,
     fundingTransactionID: string,
+    feeRecipient: string,
     feeRateMultiplier?: number,
     customFeeRate?: bigint
   ): Promise<Transaction> {
@@ -197,7 +199,7 @@ export abstract class AbstractDLCHandler {
       multisigPayment,
       fundingPayment,
       feeRate,
-      vault.btcFeeRecipient,
+      feeRecipient,
       vault.btcRedeemFeeBasisPoints.toBigInt()
     );
   }
@@ -207,6 +209,7 @@ export abstract class AbstractDLCHandler {
     depositAmount: bigint,
     attestorGroupPublicKey: string,
     fundingTransactionID: string,
+    feeRecipient: string,
     feeRateMultiplier?: number,
     customFeeRate?: bigint
   ): Promise<Transaction> {
@@ -225,7 +228,7 @@ export abstract class AbstractDLCHandler {
       multisigPayment,
       fundingPayment,
       feeRate,
-      vault.btcFeeRecipient,
+      feeRecipient,
       vault.btcMintFeeBasisPoints.toBigInt()
     );
   }

--- a/src/dlc-handlers/ledger-dlc-handler.ts
+++ b/src/dlc-handlers/ledger-dlc-handler.ts
@@ -236,6 +236,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
     vault: RawVault,
     depositAmount: bigint,
     attestorGroupPublicKey: string,
+    feeRecipient: string,
     feeRateMultiplier?: number,
     customFeeRate?: bigint
   ): Promise<Transaction> {
@@ -260,7 +261,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
         multisigPayment,
         fundingPayment,
         feeRate,
-        vault.btcFeeRecipient,
+        feeRecipient,
         vault.btcMintFeeBasisPoints.toBigInt()
       );
 
@@ -315,6 +316,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
     withdrawAmount: bigint,
     attestorGroupPublicKey: string,
     fundingTransactionID: string,
+    feeRecipient: string,
     feeRateMultiplier?: number,
     customFeeRate?: bigint
   ): Promise<Transaction> {
@@ -334,7 +336,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
         multisigPayment,
         fundingPayment,
         feeRate,
-        vault.btcFeeRecipient,
+        feeRecipient,
         vault.btcRedeemFeeBasisPoints.toBigInt()
       );
 
@@ -377,6 +379,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
     depositAmount: bigint,
     attestorGroupPublicKey: string,
     fundingTransactionID: string,
+    feeRecipient: string,
     feeRateMultiplier?: number,
     customFeeRate?: bigint
   ): Promise<Transaction> {
@@ -393,7 +396,7 @@ export class LedgerDLCHandler extends AbstractDLCHandler {
       multisigPayment,
       fundingPayment,
       feeRate,
-      vault.btcFeeRecipient,
+      feeRecipient,
       vault.btcMintFeeBasisPoints.toBigInt()
     );
 

--- a/src/functions/ethereum/ethereum-functions.ts
+++ b/src/functions/ethereum/ethereum-functions.ts
@@ -245,6 +245,16 @@ export async function getRawVault(
   }
 }
 
+export async function getFeeRecipient(dlcManagerContract: Contract): Promise<string> {
+  try {
+    const feeRecipient: string = await dlcManagerContract.btcFeeRecipient();
+    if (!feeRecipient) throw new EthereumError('Fee Recipient not found');
+    return feeRecipient;
+  } catch (error) {
+    throw new EthereumError(`Could not fetch Fee Recipient: ${error}`);
+  }
+}
+
 export async function setupVault(dlcManagerContract: Contract): Promise<any | undefined> {
   try {
     await dlcManagerContract.callStatic.setupVault();


### PR DESCRIPTION
This PR updates the PSBT creation process so that the `Fee Recipient` value is no longer retrieved from the `Vault` object but is instead passed as an external argument. This change allows the value to be fetched directly from the smart contract, eliminating the need to read the static `Vault` value.