### PR TITLE
feat: get xrpl reserve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "dlc-btc-lib",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "This library provides a comprehensive set of interfaces and functions for minting dlcBTC tokens on supported blockchains.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/functions/ripple/ripple.functions.ts
+++ b/src/functions/ripple/ripple.functions.ts
@@ -18,6 +18,7 @@ import {
   Wallet,
   convertHexToString,
   convertStringToHex,
+  dropsToXrp,
   multisign,
 } from 'xrpl';
 
@@ -27,7 +28,12 @@ import {
 } from '../../constants/ripple.constants.js';
 import { RippleError } from '../../models/errors.js';
 import { RawVault } from '../../models/ethereum-models.js';
-import { SignResponse, SignatureType, XRPLSignatures } from '../../models/ripple.model.js';
+import {
+  SignResponse,
+  SignatureType,
+  XRPLAccountBalanceAndReserveData,
+  XRPLSignatures,
+} from '../../models/ripple.model.js';
 import { shiftValue, unshiftValue } from '../../utilities/index.js';
 
 function hexFieldsToLowercase(vault: RawVault): RawVault {
@@ -360,6 +366,63 @@ export async function getAllXRPLVaults(
   } catch (error) {
     throw new RippleError(`Error getting Vaults: ${error}`);
   }
+}
+
+/**
+ * Calculates the reserve requirements and available balance for an XRPL address.
+ *
+ * @param xrplClient - An already connected XRPL client instance
+ * @param address - The XRPL address to check
+ *
+ * @returns Object containing:
+ *   - balance - Total XRP balance of the account
+ *   - availableBalance - XRP available for spending (total balance minus reserve)
+ *   - ownerCount - Number of objects owned by this address
+ *   - baseReserve - Base reserve requirement in XRP
+ *   - ownerReserve - Per-object reserve requirement in XRP
+ *   - totalReserve - Total reserve requirement (baseReserve + ownerReserve * ownerCount)
+ *
+ * @throws {RippleError} When validated ledger information cannot be retrieved
+ */
+export async function getAddressBalanceAndReserve(
+  xrplClient: Client,
+  address: string
+): Promise<XRPLAccountBalanceAndReserveData> {
+  const accountInfo = await xrplClient.request({
+    command: 'account_info',
+    account: address,
+    ledger_index: 'validated',
+  });
+
+  const serverInfo = await xrplClient.request({
+    command: 'server_info',
+  });
+
+  const serverInfoValidatedLedger = serverInfo.result.info.validated_ledger;
+
+  if (!serverInfoValidatedLedger) {
+    throw new RippleError('Validated Ledger not found');
+  }
+
+  const ownerCount = accountInfo.result.account_data.OwnerCount;
+  const baseReserve = dropsToXrp(serverInfoValidatedLedger.reserve_base_xrp);
+  const ownerReserve = dropsToXrp(serverInfoValidatedLedger.reserve_inc_xrp);
+
+  const totalReserve = new Decimal(baseReserve)
+    .plus(new Decimal(ownerReserve).times(ownerCount))
+    .toNumber();
+
+  const balance = dropsToXrp(accountInfo.result.account_data.Balance);
+  const availableBalance = new Decimal(balance).minus(totalReserve).toNumber();
+
+  return {
+    balance,
+    availableBalance,
+    ownerCount,
+    baseReserve,
+    ownerReserve,
+    totalReserve,
+  };
 }
 
 export async function signAndSubmitRippleTransaction(

--- a/src/functions/ripple/ripple.functions.ts
+++ b/src/functions/ripple/ripple.functions.ts
@@ -400,13 +400,11 @@ export async function getAddressBalanceAndReserve(
 
   const serverInfoValidatedLedger = serverInfo.result.info.validated_ledger;
 
-  if (!serverInfoValidatedLedger) {
-    throw new RippleError('Validated Ledger not found');
-  }
+  if (!serverInfoValidatedLedger) throw new RippleError('Validated Ledger not found');
 
   const ownerCount = accountInfo.result.account_data.OwnerCount;
-  const baseReserve = dropsToXrp(serverInfoValidatedLedger.reserve_base_xrp);
-  const ownerReserve = dropsToXrp(serverInfoValidatedLedger.reserve_inc_xrp);
+  const baseReserve = serverInfoValidatedLedger.reserve_base_xrp;
+  const ownerReserve = serverInfoValidatedLedger.reserve_inc_xrp;
 
   const totalReserve = new Decimal(baseReserve)
     .plus(new Decimal(ownerReserve).times(ownerCount))

--- a/src/functions/ripple/ripple.functions.ts
+++ b/src/functions/ripple/ripple.functions.ts
@@ -371,6 +371,8 @@ export async function getAllXRPLVaults(
 /**
  * Calculates the reserve requirements and available balance for an XRPL address.
  *
+ * @see {@link https://xrpl.org/docs/concepts/accounts/reserves} for more information about XRPL reserves
+ *
  * @param xrplClient - An already connected XRPL client instance
  * @param address - The XRPL address to check
  *

--- a/src/models/ripple.model.ts
+++ b/src/models/ripple.model.ts
@@ -21,3 +21,12 @@ export interface MultisignatureTransactionResponse {
   tx_blob: string;
   autoFillValues: AutoFillValues;
 }
+
+export interface XRPLAccountBalanceAndReserveData {
+  balance: number;
+  availableBalance: number;
+  ownerCount: number;
+  baseReserve: number;
+  ownerReserve: number;
+  totalReserve: number;
+}

--- a/tests/unit/xrpl-functions.test.ts
+++ b/tests/unit/xrpl-functions.test.ts
@@ -1,5 +1,21 @@
-import { decodeURI } from '../../src/functions/ripple/ripple.functions';
+import { Client } from 'xrpl';
+
+import {
+  decodeURI,
+  getAddressBalanceAndReserve,
+} from '../../src/functions/ripple/ripple.functions';
+import { RippleError } from '../../src/models/errors';
 import { TEST_VAULT_4, TEST_VAULT_5 } from '../mocks/ethereum-vault.test.constants';
+
+jest.mock('xrpl', () => {
+  const actualXRPL = jest.requireActual('xrpl');
+  return {
+    ...actualXRPL,
+    Client: jest.fn().mockImplementation(() => ({
+      request: jest.fn(),
+    })),
+  };
+});
 
 describe('XRPL Functions', () => {
   describe('decodeURI', () => {
@@ -19,6 +35,180 @@ describe('XRPL Functions', () => {
       const decodedURI = decodeURI(encodedURI);
 
       expect(decodedURI).toEqual(TEST_VAULT_5);
+    });
+  });
+  describe('getAddressReserve', () => {
+    let mockClient: jest.Mocked<Client>;
+
+    const testAddress = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh';
+
+    beforeEach(() => {
+      mockClient = new Client('wss://example.com') as jest.Mocked<Client>;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should calculate reserve and available balance correctly', async () => {
+      mockClient.request.mockImplementation((request: any) => {
+        if (request.command === 'account_info') {
+          return Promise.resolve({
+            result: {
+              account_data: {
+                OwnerCount: 5,
+                Balance: '25000000',
+              },
+            },
+          });
+        } else if (request.command === 'server_info') {
+          return Promise.resolve({
+            result: {
+              info: {
+                validated_ledger: {
+                  reserve_base_xrp: '10000000',
+                  reserve_inc_xrp: '2000000',
+                },
+              },
+            },
+          });
+        }
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      const result = await getAddressBalanceAndReserve(mockClient, testAddress);
+
+      expect(mockClient.request).toHaveBeenCalledTimes(2);
+      expect(result.ownerCount).toBe(5);
+      expect(result.baseReserve).toBe(10);
+      expect(result.ownerReserve).toBe(2);
+      expect(result.totalReserve).toBe(20);
+      expect(result.balance).toBe(25);
+      expect(result.availableBalance).toBe(5);
+    });
+
+    it('should throw RippleError when validated_ledger is not found', async () => {
+      mockClient.request.mockImplementation((request: any) => {
+        if (request.command === 'account_info') {
+          return Promise.resolve({
+            result: {
+              account_data: {
+                OwnerCount: 5,
+                Balance: '25000000',
+              },
+            },
+          });
+        } else if (request.command === 'server_info') {
+          return Promise.resolve({
+            result: {
+              info: {
+                // No validated_ledger property
+              },
+            },
+          });
+        }
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      await expect(getAddressBalanceAndReserve(mockClient, testAddress)).rejects.toThrow(
+        new RippleError('Validated Ledger not found')
+      );
+    });
+
+    it('should handle zero owner count correctly', async () => {
+      mockClient.request.mockImplementation((request: any) => {
+        if (request.command === 'account_info') {
+          return Promise.resolve({
+            result: {
+              account_data: {
+                OwnerCount: 0,
+                Balance: '15000000',
+              },
+            },
+          });
+        } else if (request.command === 'server_info') {
+          return Promise.resolve({
+            result: {
+              info: {
+                validated_ledger: {
+                  reserve_base_xrp: '10000000',
+                  reserve_inc_xrp: '2000000',
+                },
+              },
+            },
+          });
+        }
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      const result = await getAddressBalanceAndReserve(mockClient, testAddress);
+
+      expect(result.totalReserve).toBe(10);
+      expect(result.availableBalance).toBe(5);
+    });
+
+    it('should handle very large owner counts correctly', async () => {
+      const largeOwnerCount = 1000;
+      mockClient.request.mockImplementation((request: any) => {
+        if (request.command === 'account_info') {
+          return Promise.resolve({
+            result: {
+              account_data: {
+                OwnerCount: largeOwnerCount,
+                Balance: '3000000000',
+              },
+            },
+          });
+        } else if (request.command === 'server_info') {
+          return Promise.resolve({
+            result: {
+              info: {
+                validated_ledger: {
+                  reserve_base_xrp: '10000000',
+                  reserve_inc_xrp: '2000000',
+                },
+              },
+            },
+          });
+        }
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      const result = await getAddressBalanceAndReserve(mockClient, testAddress);
+
+      expect(result.totalReserve).toBe(2010);
+      expect(result.availableBalance).toBe(990);
+    });
+
+    it('should return zero available balance when balance exactly meets reserve', async () => {
+      mockClient.request.mockImplementation((request: any) => {
+        if (request.command === 'account_info') {
+          return Promise.resolve({
+            result: {
+              account_data: {
+                OwnerCount: 1,
+                Balance: '12000000',
+              },
+            },
+          });
+        } else if (request.command === 'server_info') {
+          return Promise.resolve({
+            result: {
+              info: {
+                validated_ledger: {
+                  reserve_base_xrp: '10000000',
+                  reserve_inc_xrp: '2000000',
+                },
+              },
+            },
+          });
+        }
+        return Promise.reject(new Error('Unexpected request'));
+      });
+
+      const result = await getAddressBalanceAndReserve(mockClient, testAddress);
+
+      expect(result.availableBalance).toBe(0);
     });
   });
 });

--- a/tests/unit/xrpl-functions.test.ts
+++ b/tests/unit/xrpl-functions.test.ts
@@ -66,8 +66,8 @@ describe('XRPL Functions', () => {
             result: {
               info: {
                 validated_ledger: {
-                  reserve_base_xrp: '10000000',
-                  reserve_inc_xrp: '2000000',
+                  reserve_base_xrp: 10,
+                  reserve_inc_xrp: 2,
                 },
               },
             },
@@ -131,8 +131,8 @@ describe('XRPL Functions', () => {
             result: {
               info: {
                 validated_ledger: {
-                  reserve_base_xrp: '10000000',
-                  reserve_inc_xrp: '2000000',
+                  reserve_base_xrp: 10,
+                  reserve_inc_xrp: 2,
                 },
               },
             },
@@ -164,8 +164,8 @@ describe('XRPL Functions', () => {
             result: {
               info: {
                 validated_ledger: {
-                  reserve_base_xrp: '10000000',
-                  reserve_inc_xrp: '2000000',
+                  reserve_base_xrp: 10,
+                  reserve_inc_xrp: 2,
                 },
               },
             },
@@ -196,8 +196,8 @@ describe('XRPL Functions', () => {
             result: {
               info: {
                 validated_ledger: {
-                  reserve_base_xrp: '10000000',
-                  reserve_inc_xrp: '2000000',
+                  reserve_base_xrp: 10,
+                  reserve_inc_xrp: 2,
                 },
               },
             },


### PR DESCRIPTION
# Add Vault Event System and Testing

## Overview
Added a utility function `getAddressBalanceAndReserve` to calculate reserve requirements and available balances for XRPL addresses. This enhancement provides crucial information about how much XRP is actually available for spending versus what's locked in reserves.

## New Features
### Core Balance Calculation
* `getAddressBalanceAndReserve`: Retrieves and calculates detailed balance information for XRPL accounts
* Returns comprehensive balance data including total and available XRP
* Calculates base reserve, owner reserve, and total reserve requirements
* Handles server information retrieval for current reserve settings

### Data Points Provided
* `balance`: Total XRP balance of the account
* `availableBalance`: Spendable XRP (total minus reserves)
* `ownerCount`: Number of objects owned by the address
* `baseReserve`: Current base reserve requirement
* `ownerReserve`: Per-object reserve requirement
* `totalReserve`: Total calculated reserve for the account

## Implementation Details
* Uses the XRPL client to fetch validated account information
* Retrieves current network reserve requirements from server info
* Calculates owner reserves based on the number of account objects
* Determines available balance by subtracting total reserve from balance
* Handles error conditions for missing validated ledger information

## Testing
* Comprehensive test suite covering:
   * New accounts with minimal objects
   * Accounts with many owned objects
   * Edge cases with reserves approaching total balance
   * Error conditions when validated ledger isn't available
   * Various XRP balance scenarios